### PR TITLE
fix default feed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,13 +14,14 @@ class NewsSkill(OVOSCommonPlaybackSkill):
     # default feeds per language (optional)
     langdefaults = {
         "pt-pt": "TSF",
-        "es": "RNE",
+        "es-es": "RNE",
         "ca-es": "CCMA",
         "en-gb": "BBC",
         "en-us": "NPR",
         "en-au": "ABC",
         "en-ca": "CBC",
-        "it": "GR1"
+        "it-it": "GR1",
+        "de-de": "DLF - Die Nachrichten"
     }
     # all news streams
     lang2news = {
@@ -279,7 +280,7 @@ class NewsSkill(OVOSCommonPlaybackSkill):
                 "secondary_langs": ["pt"]
             }
         },
-        "de": {
+        "de-de": {
             "DLF - Die Nachrichten": {
                 "aliases": ["DLF", "deutschlandfunk"],
                 "uri": "rss//https://www.deutschlandfunk.de/podcast-nachrichten.1257.de.podcast.xml",
@@ -417,7 +418,7 @@ class NewsSkill(OVOSCommonPlaybackSkill):
                 "playback": PlaybackType.AUDIO
             }
         },
-        "nl": {
+        "nl-nl": {
             "VRT": {
                 "aliases": ["VRT Nieuws", "VRT"],
                 "uri": "http://progressive-audio.vrtcdn.be/content/fixed/11_11niws-snip_hi.mp3",
@@ -427,7 +428,7 @@ class NewsSkill(OVOSCommonPlaybackSkill):
                 "playback": PlaybackType.AUDIO
             }
         },
-        "sv": {
+        "sv-se": {
             "Ekot": {
                 "aliases": ["Ekot"],
                 "uri": "rss//https://api.sr.se/api/rss/pod/3795",
@@ -437,7 +438,7 @@ class NewsSkill(OVOSCommonPlaybackSkill):
                 "playback": PlaybackType.AUDIO
             }
         },
-        "es": {
+        "es-es": {
             "RNE": {
                 "aliases": ["RNE", "National Spanish Radio",
                             "Radio Nacional de España"],
@@ -460,7 +461,7 @@ class NewsSkill(OVOSCommonPlaybackSkill):
                 "secondary_langs": ["es"]
             }
         },
-        "fi": {
+        "fi-fi": {
             "YLE": {
                 "aliases": ["YLE", "YLE News Radio"],
                 "uri": "rss//https://feeds.yle.fi/areena/v1/series/1-1440981.rss",
@@ -470,7 +471,7 @@ class NewsSkill(OVOSCommonPlaybackSkill):
                 "playback": PlaybackType.AUDIO
             }
         },
-        "it": {
+        "it-it": {
             "GR1": {
                 "aliases": ["GR1", "Rai GR1", "Rai", "Radio Giornale 1"],
                 "uri": "news//https://www.raiplaysound.it",
@@ -530,15 +531,15 @@ class NewsSkill(OVOSCommonPlaybackSkill):
         if self.voc_match(phrase, "en"):
             langs.append("en")
         if self.voc_match(phrase, "es"):
-            langs.append("es")
+            langs.append("es-es")
         if self.voc_match(phrase, "de"):
-            langs.append("de")
+            langs.append("de-de")
         if self.voc_match(phrase, "nl"):
-            langs.append("nl")
+            langs.append("nl-nl")
         if self.voc_match(phrase, "fi"):
-            langs.append("fi")
+            langs.append("fi-fi")
         if self.voc_match(phrase, "sv"):
-            langs.append("sv")
+            langs.append("sv-se")
 
         langs += [l.split("-")[0] for l in langs]
         return list(set(langs))
@@ -570,23 +571,21 @@ class NewsSkill(OVOSCommonPlaybackSkill):
     @ocp_featured_media()
     def news_playlist(self):
         entries = []
-        default_feeds = []
+        
+        for lang in self.lang2news:
+            default_feed = self.langdefaults.get(lang)
+            if lang == self.lang:
+                default_feed = self.settings.get("default_feed") or default_feed
 
-        # play user preference if set in skill settings
-        feed = self.settings.get("default_feed")
-        if not feed and self.lang in self.langdefaults:
-            feed = self.langdefaults.get(self.lang)
-
-        for l in self.lang2news:
-            for k, v in self.lang2news[l].items():
-                if k == feed:
-                    v["is_default"] = True
-                v["lang"] = l
-                v["title"] = v.get("title") or k
-                v["bg_image"] = v.get("bg_image") or self.default_bg
-                v["skill_logo"] = self.skill_icon
-                if v["uri"]:
-                    entries.append(v)
+            for feed, config in self.lang2news[lang].items():
+                if feed == default_feed:
+                    config["is_default"] = True
+                config["lang"] = lang
+                config["title"] = config.get("title") or feed
+                config["bg_image"] = config.get("bg_image") or self.default_bg
+                config["skill_logo"] = self.skill_icon
+                if config["uri"]:
+                    entries.append(config)
         return entries
 
     @ocp_search()


### PR DESCRIPTION
problem: `is_default` only gets set with your own language (`self.lang`), but should be set for every lang 

changes:
* `lang2news` feeds are now defined with the full lang code across the board
* default feeds are now set for every language. Ie. if one issues a feed from a foreign language (and no feed name/alias is uttered) the default is prioritized. 